### PR TITLE
feat: support ECS task as SSM target

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This action allows you to forward a port from a remote machine to your local mac
 
 | Name | Required | Description |
 | --- | --- | --- |
-| target | true | The target instance ID |
+| target | true | The target instance ID or ECS task container |
 | host | true | The remote host to forward the port from |
 | port | true | The remote port to forward |
 | local-port | true | The local port to forward to |
@@ -34,10 +34,19 @@ jobs:
         aws-region: ap-northeast-1
         role-to-assume: arn:aws:iam::123456789012:role/role-name
 
-    - name: Port forward
+    - name: Port forward to EC2 instance
       uses: enkhjile/aws-ssm-remote-port-forwarding-action@v1
       with:
         target: i-1234567890abcdef0
+        host: my-rds-instance.123456789012.ap-northeast-1.rds.amazonaws.com
+        port: 3306
+        local-port: 3306
+
+    - name: Port forward to ECS or Fargate task container
+      uses: enkhjile/aws-ssm-remote-port-forwarding-action@v1
+      with:
+        # target for ECS task container is "ecs:<ecs-cluster-name>_<task-id>_<task-container-runtime-id>"
+        target: ecs:my-ecs-cluster_1234abcd5678efab9012cdef3456abcd_1234abcd5678efab9012cdef3456abcd-1234567890
         host: my-rds-instance.123456789012.ap-northeast-1.rds.amazonaws.com
         port: 3306
         local-port: 3306

--- a/dist/main/connect-with-port-forwarding.sh
+++ b/dist/main/connect-with-port-forwarding.sh
@@ -16,21 +16,21 @@ done
 
 # Check if required parameters were provided
 if [ -z "${target}" ] || [ -z "${host}" ] || [ -z "${port}" ] || [ -z "${local_port}" ]; then
-  echo "Usage: $0 -t <target_instance_id> -h <remote_host> -p <remote_port> -l <local_port>" >&2
+  echo "Usage: $0 -t <target_instance_id|target_ecs_task_container> -h <remote_host> -p <remote_port> -l <local_port>" >&2
   exit 1
 fi
 
-# Check if the target instance or ECS task actually exists
+# Check if the target instance or ECS task container actually exists
 if [[ "${target}" == ecs* ]]; then
   ecs_target=${target##*:}
   ecs_cluster_name=${ecs_target%%_*}
-  ecs_task_runtime_id=${ecs_target##*_}
-  ecs_task_id=${ecs_task_runtime_id%-*}
+  ecs_task_container_runtime_id=${ecs_target##*_}
+  ecs_task_id=${ecs_task_container_runtime_id%-*}
   target_exists=$(aws ecs describe-tasks \
     --cluster $ecs_cluster_name \
     --tasks $ecs_task_id \
     --query "tasks[*].containers[*].runtimeId" \
-    --output text | grep $ecs_task_runtime_id)
+    --output text | grep $ecs_task_container_runtime_id)
 else
   target_exists=$(aws ec2 describe-instances \
     --instance-ids "${target}" \

--- a/src/connect-with-port-forwarding.sh
+++ b/src/connect-with-port-forwarding.sh
@@ -16,21 +16,21 @@ done
 
 # Check if required parameters were provided
 if [ -z "${target}" ] || [ -z "${host}" ] || [ -z "${port}" ] || [ -z "${local_port}" ]; then
-  echo "Usage: $0 -t <target_instance_id> -h <remote_host> -p <remote_port> -l <local_port>" >&2
+  echo "Usage: $0 -t <target_instance_id|target_ecs_task_container> -h <remote_host> -p <remote_port> -l <local_port>" >&2
   exit 1
 fi
 
-# Check if the target instance or ECS task actually exists
+# Check if the target instance or ECS task container actually exists
 if [[ "${target}" == ecs* ]]; then
   ecs_target=${target##*:}
   ecs_cluster_name=${ecs_target%%_*}
-  ecs_task_runtime_id=${ecs_target##*_}
-  ecs_task_id=${ecs_task_runtime_id%-*}
+  ecs_task_container_runtime_id=${ecs_target##*_}
+  ecs_task_id=${ecs_task_container_runtime_id%-*}
   target_exists=$(aws ecs describe-tasks \
     --cluster $ecs_cluster_name \
     --tasks $ecs_task_id \
     --query "tasks[*].containers[*].runtimeId" \
-    --output text | grep $ecs_task_runtime_id)
+    --output text | grep $ecs_task_container_runtime_id)
 else
   target_exists=$(aws ec2 describe-instances \
     --instance-ids "${target}" \


### PR DESCRIPTION
#### Summary
Add support for using an ECS or Fargate running task as target.

#### Testing
Tested it successfully by running the edited script version from GitHub Actions.  A couple inputs come from a previous step which runs the discovery of the database instance and the ECS task container to use as bastion.
```yaml
      - name: SSM port forward to Database instance
        run: |
          ./scripts/connect-with-port-forwarding.sh \
            -t "${{ steps.ssmparams.outputs.target }}" \
            -h "${{ steps.ssmparams.outputs.host }}" \
            -p 5432 -l 5432
```